### PR TITLE
Faker: Guarantee globalMutex initialization before use

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -60,6 +60,7 @@ set(FAKER_SOURCES
 	faker-x11.cpp
 	${FAKER_XCB_SOURCES}
 	fakerconfig.cpp
+	SafeCriticalSection.cpp
 	GLXDrawableHash.cpp
 	glxvisual.cpp
 	PixmapHash.cpp

--- a/server/SafeCriticalSection.cpp
+++ b/server/SafeCriticalSection.cpp
@@ -1,0 +1,19 @@
+/* Copyright (C) 2015 Open Text SA and/or Open Text ULC (in Canada).
+ *
+ * This library is free software and may be redistributed and/or modified under
+ * the terms of the wxWindows Library License, Version 3.1 or (at your option)
+ * any later version.  The full license is in the LICENSE.txt file included
+ * with this distribution.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * wxWindows Library License for more details.
+ */
+
+#include "SafeCriticalSection.h"
+
+using namespace vglserver;
+
+SafeCriticalSection *SafeCriticalSection::instance=NULL;
+vglutil::CriticalSection SafeCriticalSection::instanceMutex;

--- a/server/SafeCriticalSection.h
+++ b/server/SafeCriticalSection.h
@@ -1,0 +1,49 @@
+/* Copyright (C)2004 Landmark Graphics Corporation
+ * Copyright (C)2005 Sun Microsystems, Inc.
+ * Copyright (C)2011, 2014 D. R. Commander
+ * Copyright (C)2015 Open Text SA and/or Open Text ULC (in Canada).
+ *
+ * This library is free software and may be redistributed and/or modified under
+ * the terms of the wxWindows Library License, Version 3.1 or (at your option)
+ * any later version.  The full license is in the LICENSE.txt file included
+ * with this distribution.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * wxWindows Library License for more details.
+ */
+
+#ifndef __SAFECRITICALSECTION_H__
+#define __SAFECRITICALSECTION_H__
+
+#include "Mutex.h"
+
+// A CriticalSection instance that is safe to run even if constructors for
+// static C++ objects have not yet been called.
+
+namespace vglserver
+{
+	class SafeCriticalSection : public vglutil::CriticalSection
+	{
+		public:
+
+			static SafeCriticalSection *getInstance(void)
+			{
+				if(instance==NULL)
+				{
+					vglutil::CriticalSection::SafeLock l(instanceMutex);
+					if(instance==NULL) instance=new SafeCriticalSection;
+				}
+				return instance;
+			}
+		private:
+
+			static SafeCriticalSection *instance;
+			static vglutil::CriticalSection instanceMutex;
+	};
+}
+
+#define globalMutex (*(vglserver::SafeCriticalSection::getInstance()))
+
+#endif // __SAFECRITICALSECTION_H__

--- a/server/faker-sym.h
+++ b/server/faker-sym.h
@@ -21,6 +21,7 @@
 #define GLX_GLXEXT_PROTOTYPES
 #include "glx.h"
 #include "Log.h"
+#include "SafeCriticalSection.h"
 #ifdef FAKEXCB
 extern "C" {
 #ifdef SYSXCBHEADERS
@@ -44,7 +45,6 @@ namespace vglfaker
 {
 	extern void safeExit(int);
 	extern void init(void);
-	extern vglutil::CriticalSection globalMutex;
 	#ifdef FAKEXCB
 	extern __thread int fakerLevel;
 	#endif
@@ -57,7 +57,7 @@ namespace vglfaker
 #define CHECKSYM_NONFATAL(s) {  \
 	if(!__##s) {  \
 		vglfaker::init();  \
-		vglutil::CriticalSection::SafeLock l(vglfaker::globalMutex);  \
+		vglserver::SafeCriticalSection::SafeLock l(globalMutex);  \
 		if(!__##s) __##s=(_##s##Type)vglfaker::loadSymbol(#s, true);  \
 	}  \
 }
@@ -65,7 +65,7 @@ namespace vglfaker
 #define CHECKSYM(s) {  \
 	if(!__##s) {  \
 		vglfaker::init();  \
-		vglutil::CriticalSection::SafeLock l(vglfaker::globalMutex);  \
+		vglserver::SafeCriticalSection::SafeLock l(globalMutex);  \
 		if(!__##s) __##s=(_##s##Type)vglfaker::loadSymbol(#s);  \
 	}  \
 	if(!__##s) vglfaker::safeExit(1);  \

--- a/server/faker.cpp
+++ b/server/faker.cpp
@@ -19,6 +19,7 @@
 #include "ContextHash.h"
 #include "DisplayHash.h"
 #include "GLXDrawableHash.h"
+#include "SafeCriticalSection.h"
 #include "PixmapHash.h"
 #include "ReverseConfigHash.h"
 #include "VisualHash.h"
@@ -35,7 +36,6 @@ namespace vglfaker
 {
 
 Display *dpy3D=NULL;
-CriticalSection globalMutex;
 bool deadYet=false;
 int traceLevel=0;
 #ifdef FAKEXCB
@@ -112,7 +112,7 @@ void init(void)
 	static int init=0;
 
 	if(init) return;
-	CriticalSection::SafeLock l(globalMutex);
+	SafeCriticalSection::SafeLock l(globalMutex);
 	if(init) return;
 	init=1;
 
@@ -176,7 +176,7 @@ void *_vgl_dlopen(const char *file, int mode)
 {
 	if(!__dlopen)
 	{
-		CriticalSection::SafeLock l(vglfaker::globalMutex);
+		SafeCriticalSection::SafeLock l(globalMutex);
 		if(!__dlopen)
 		{
 			dlerror();  // Clear error state

--- a/server/faker.h
+++ b/server/faker.h
@@ -28,7 +28,6 @@
 
 namespace vglfaker
 {
-	extern vglutil::CriticalSection globalMutex;
 	extern Display *dpy3D;
 	extern void safeExit(int);
 	extern int deadYet;
@@ -71,9 +70,9 @@ static inline int drawingToRight(void)
 static inline int isDead(void)
 {
 	int retval=0;
-	vglfaker::globalMutex.lock(false);
+	globalMutex.lock(false);
 	retval=vglfaker::deadYet;
-	vglfaker::globalMutex.unlock(false);
+	globalMutex.unlock(false);
 	return retval;
 }
 


### PR DESCRIPTION
A shared object's _init() (think MainWin) can call VGL functions before
VGL's own _init() -> __static_initialization_and_destruction_0() gets
a chance to call the the global mutex constructor and change the mutex type
from 0 (PTHREAD_MUTEX_NORMAL) to 1 (PTHREAD_MUTEX_RECURSIVE), resulting in
vglfaker::init() deadlocking.

Seen in MATLAB's need_softwareopengl utility, and Ansys 16.1+ DesignModeler.