### PR TITLE
Faker: Switch from __thread to pthread_*() for thread-local storage o…

### DIFF
--- a/server/faker-gl.cpp
+++ b/server/faker-gl.cpp
@@ -65,7 +65,7 @@ extern "C" {
 
 void glFinish(void)
 {
-	if(vglfaker::excludeCurrent) { _glFinish();  return; }
+	if(vglfaker::getExcludeCurrent()) { _glFinish();  return; }
 
 	TRY();
 
@@ -83,7 +83,7 @@ void glFlush(void)
 {
 	static double lastTime=-1.;  double thisTime;
 
-	if(vglfaker::excludeCurrent) { _glFlush();  return; }
+	if(vglfaker::getExcludeCurrent()) { _glFlush();  return; }
 
 	TRY();
 
@@ -108,7 +108,7 @@ void glFlush(void)
 
 void glXWaitGL(void)
 {
-	if(vglfaker::excludeCurrent) { _glXWaitGL();  return; }
+	if(vglfaker::getExcludeCurrent()) { _glXWaitGL();  return; }
 
 	TRY();
 
@@ -130,7 +130,7 @@ void glXWaitGL(void)
 
 void glDrawBuffer(GLenum mode)
 {
-	if(vglfaker::excludeCurrent) { _glDrawBuffer(mode);  return; }
+	if(vglfaker::getExcludeCurrent()) { _glDrawBuffer(mode);  return; }
 
 	TRY();
 
@@ -163,7 +163,7 @@ void glDrawBuffer(GLenum mode)
 
 void glPopAttrib(void)
 {
-	if(vglfaker::excludeCurrent) { _glPopAttrib();  return; }
+	if(vglfaker::getExcludeCurrent()) { _glPopAttrib();  return; }
 
 	TRY();
 
@@ -198,7 +198,7 @@ void glPopAttrib(void)
 
 void glViewport(GLint x, GLint y, GLsizei width, GLsizei height)
 {
-	if(vglfaker::excludeCurrent) { _glViewport(x, y, width, height);  return; }
+	if(vglfaker::getExcludeCurrent()) { _glViewport(x, y, width, height);  return; }
 
 	TRY();
 

--- a/server/faker-glx.cpp
+++ b/server/faker-glx.cpp
@@ -1120,7 +1120,7 @@ Display *glXGetCurrentDisplay(void)
 {
 	Display *dpy=NULL;  VirtualWin *vw=NULL;
 
-	if(vglfaker::excludeCurrent) return _glXGetCurrentDisplay();
+	if(vglfaker::getExcludeCurrent()) return _glXGetCurrentDisplay();
 
 	TRY();
 
@@ -1148,7 +1148,7 @@ GLXDrawable glXGetCurrentDrawable(void)
 {
 	VirtualWin *vw=NULL;  GLXDrawable draw=_glXGetCurrentDrawable();
 
-	if(vglfaker::excludeCurrent) return draw;
+	if(vglfaker::getExcludeCurrent()) return draw;
 
 	TRY();
 
@@ -1166,7 +1166,7 @@ GLXDrawable glXGetCurrentReadDrawable(void)
 {
 	VirtualWin *vw=NULL;  GLXDrawable read=_glXGetCurrentReadDrawable();
 
-	if(vglfaker::excludeCurrent) return read;
+	if(vglfaker::getExcludeCurrent()) return read;
 
 	TRY();
 
@@ -1637,15 +1637,15 @@ Bool glXMakeCurrent(Display *dpy, GLXDrawable drawable, GLXContext ctx)
 		// Overlay context.  Hand off to the 2D X server.
 		retval=_glXMakeCurrent(dpy, drawable, ctx);
 		winhash.setOverlay(dpy, drawable);
-		vglfaker::excludeCurrent=true;
+		vglfaker::setExcludeCurrent(true);
 		return retval;
 	}
  	if(dpyhash.find(dpy))
 	{
-		vglfaker::excludeCurrent=true;
+		vglfaker::setExcludeCurrent(true);
 		return _glXMakeCurrent(dpy, drawable, ctx);
 	}
-	vglfaker::excludeCurrent=false;
+	vglfaker::setExcludeCurrent(false);
 
 		opentrace(glXMakeCurrent);  prargd(dpy);  prargx(drawable);  prargx(ctx);
 		starttrace();
@@ -1737,15 +1737,15 @@ Bool glXMakeContextCurrent(Display *dpy, GLXDrawable draw, GLXDrawable read,
 		retval=_glXMakeContextCurrent(dpy, draw, read, ctx);
 		winhash.setOverlay(dpy, draw);
 		winhash.setOverlay(dpy, read);
-		vglfaker::excludeCurrent=true;
+		vglfaker::setExcludeCurrent(true);
 		return retval;
 	}
 	if(dpyhash.find(dpy))
 	{
-		vglfaker::excludeCurrent=true;
+		vglfaker::setExcludeCurrent(true);
 		return _glXMakeContextCurrent(dpy, draw, read, ctx);
 	}
-	vglfaker::excludeCurrent=false;
+	vglfaker::setExcludeCurrent(false);
 
 		opentrace(glXMakeContextCurrent);  prargd(dpy);  prargx(draw);
 		prargx(read);  prargx(ctx);  starttrace();
@@ -2276,7 +2276,7 @@ int glXSwapIntervalSGI(int interval)
 {
 	int retval=0;
 
-	if(vglfaker::excludeCurrent) return _glXSwapIntervalSGI(interval);
+	if(vglfaker::getExcludeCurrent()) return _glXSwapIntervalSGI(interval);
 
 		opentrace(glXSwapIntervalSGI);  prargi(interval);  starttrace();
 
@@ -2302,7 +2302,7 @@ int glXSwapIntervalSGI(int interval)
 
 void glXUseXFont(Font font, int first, int count, int list_base)
 {
-	if(vglfaker::excludeCurrent)
+	if(vglfaker::getExcludeCurrent())
 	{
 		_glXUseXFont(font, first, count, list_base);  return;
 	}

--- a/server/faker-sym.h
+++ b/server/faker-sym.h
@@ -46,7 +46,8 @@ namespace vglfaker
 	extern void init(void);
 	extern vglutil::CriticalSection globalMutex;
 	#ifdef FAKEXCB
-	extern __thread int fakerLevel;
+	extern long getFakerLevel(void);
+	extern void setFakerLevel(long v);
 	#endif
 
 	void *loadSymbol(const char *name, bool optional=false);
@@ -79,8 +80,8 @@ namespace vglfaker
 
 
 #ifdef FAKEXCB
-#define DISABLE_FAKEXCB() vglfaker::fakerLevel++;
-#define ENABLE_FAKEXCB() vglfaker::fakerLevel--;
+#define DISABLE_FAKEXCB() vglfaker::setFakerLevel(vglfaker::getFakerLevel()+1);
+#define ENABLE_FAKEXCB()  vglfaker::setFakerLevel(vglfaker::getFakerLevel()-1);
 #else
 #define DISABLE_FAKEXCB()
 #define ENABLE_FAKEXCB()

--- a/server/faker-xcb.cpp
+++ b/server/faker-xcb.cpp
@@ -41,7 +41,7 @@ const xcb_query_extension_reply_t *
 	TRY();
 
 	if(ext && !strcmp(ext->name, "GLX") && fconfig.fakeXCB
-		&& vglfaker::fakerLevel==0
+		&& vglfaker::getFakerLevel()==0
 		&& !dpyhash.find(xcbconnhash.getX11Display(conn)))
 	{
 			opentrace(xcb_get_extension_data);  prargx(conn);
@@ -79,7 +79,7 @@ xcb_glx_query_version_cookie_t
 
 	TRY();
 
-	if(!fconfig.fakeXCB || vglfaker::fakerLevel>0
+	if(!fconfig.fakeXCB || vglfaker::getFakerLevel()>0
 		|| dpyhash.find(xcbconnhash.getX11Display(conn)))
 		return _xcb_glx_query_version(conn, major_version, minor_version);
 
@@ -107,7 +107,7 @@ xcb_glx_query_version_reply_t *
 
 	TRY();
 
-	if(!fconfig.fakeXCB || vglfaker::fakerLevel>0
+	if(!fconfig.fakeXCB || vglfaker::getFakerLevel()>0
 		|| dpyhash.find(xcbconnhash.getX11Display(conn)))
 		return _xcb_glx_query_version_reply(conn, cookie, error);
 
@@ -225,7 +225,7 @@ xcb_generic_event_t *xcb_poll_for_event(xcb_connection_t *conn)
 	TRY();
 
 	if((e=_xcb_poll_for_event(conn))!=NULL && fconfig.fakeXCB
-		&& vglfaker::fakerLevel==0)
+		&& vglfaker::getFakerLevel()==0)
 		handleXCBEvent(conn, e);
 
 	CATCH();
@@ -241,7 +241,7 @@ xcb_generic_event_t *xcb_poll_for_queued_event(xcb_connection_t *conn)
 	TRY();
 
 	if((e=_xcb_poll_for_queued_event(conn))!=NULL && fconfig.fakeXCB
-		&& vglfaker::fakerLevel==0)
+		&& vglfaker::getFakerLevel()==0)
 		handleXCBEvent(conn, e);
 
 	CATCH();
@@ -257,7 +257,7 @@ xcb_generic_event_t *xcb_wait_for_event(xcb_connection_t *conn)
 	TRY();
 
 	if((e=_xcb_wait_for_event(conn))!=NULL && fconfig.fakeXCB
-		&& vglfaker::fakerLevel==0)
+		&& vglfaker::getFakerLevel()==0)
 		handleXCBEvent(conn, e);
 
 	CATCH();

--- a/server/faker.cpp
+++ b/server/faker.cpp
@@ -24,6 +24,7 @@
 #include "VisualHash.h"
 #include "WindowHash.h"
 #include "fakerconfig.h"
+#include "threadlocal.h"
 #include <dlfcn.h>
 
 
@@ -39,9 +40,9 @@ CriticalSection globalMutex;
 bool deadYet=false;
 int traceLevel=0;
 #ifdef FAKEXCB
-__thread int fakerLevel=0;
+VGL_THREAD_LOCAL(FakerLevel, long, 0)
 #endif
-__thread bool excludeCurrent=false;
+VGL_THREAD_LOCAL(ExcludeCurrent, bool, false)
 
 
 static void cleanup(void)

--- a/server/faker.h
+++ b/server/faker.h
@@ -34,10 +34,12 @@ namespace vglfaker
 	extern int deadYet;
 	extern int traceLevel;
 	#ifdef FAKEXCB
-	extern __thread int fakerLevel;
+	extern long getFakerLevel(void);
+	extern void setFakerLevel(long v);
 	#endif
 	extern bool excludeDisplay(char *name);
-	extern __thread bool excludeCurrent;
+	extern bool getExcludeCurrent(void);
+	extern void setExcludeCurrent(bool v);
 }
 
 #define _dpy3D vglfaker::dpy3D

--- a/server/threadlocal.h
+++ b/server/threadlocal.h
@@ -1,0 +1,52 @@
+/* Copyright (C) 2015 Open Text SA and/or Open Text ULC (in Canada).
+ *
+ * This library is free software and may be redistributed and/or modified under
+ * the terms of the wxWindows Library License, Version 3.1 or (at your option)
+ * any later version.  The full license is in the LICENSE.txt file included
+ * with this distribution.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * wxWindows Library License for more details.
+ */
+
+// Simple pthread-based alternative to __thread for TLS on Linux x86*.
+// Linux can't use __thread storage because it invokes __tls_get_addr which
+// blocks on a mutex which may be locked during another shared object's _init().
+
+#ifndef __THREADLOCAL_H__
+#define __THREADLOCAL_H__
+
+#ifdef _WIN32
+
+#define VGL_THREAD_LOCAL(name, type, initvalue) \
+__thread type name=initvalue; \
+type get##name(void) { return name;} \
+void set##name(type v) { name = v; }
+
+#else
+
+#define VGL_THREAD_LOCAL(name, type, initvalue) \
+static pthread_key_t get##name##Key(void) \
+{ \
+	static pthread_key_t key; \
+	static bool inited=false; \
+	if (!inited) \
+	{ \
+		if(pthread_key_create(&key, NULL)) \
+		{ \
+			vglout.println("[VGL] Error: pthread_key_create() for " #name "failed.\n"); \
+			vglfaker::safeExit(1); \
+		} \
+		pthread_setspecific(key, (const void *)initvalue); \
+		inited=true; \
+	} \
+	return key; \
+} \
+type get##name(void) { return (type) pthread_getspecific(get##name##Key()); } \
+void set##name(type v) { pthread_setspecific(get##name##Key(), (const void *)v); }
+
+#endif
+
+#endif // __THREADLOCAL_H__


### PR DESCRIPTION
…n Linux

Accessing __thread storage from -fPIC code invokes __tls_get_addr which in turn
is guarded by a mutex.  When Ansys 16.1's runwb2 launches DesignModeler
(via Static Structural -> Geometry) one of MainWin's _init() functions
invokes VGL functions while the libc TLS mutex is locked, causing a deadlock.

(C++11's thread_local compiles to the same __tls_get_addr.)