### PR TITLE
10 bpc support

### DIFF
--- a/include/fbx.h
+++ b/include/fbx.h
@@ -55,21 +55,21 @@ typedef struct
 
 
 /* Pixel formats */
-#define FBX_FORMATS 7
-enum { FBX_RGB, FBX_RGBA, FBX_BGR, FBX_BGRA, FBX_ABGR, FBX_ARGB, FBX_INDEX };
+#define FBX_FORMATS 8
+enum { FBX_RGB, FBX_RGBA, FBX_BGR, FBX_BGRA, FBX_ABGR, FBX_ARGB, FBX_r210, FBX_INDEX };
 
 static const int fbx_ps[FBX_FORMATS]=
-	{ 3, 4, 3, 4, 4, 4, 1 };
+	{ 3, 4, 3, 4, 4, 4, 4, 1 };
 static const int fbx_bgr[FBX_FORMATS]=
-	{ 0, 0, 1, 1, 1, 0, 0 };
+	{ 0, 0, 1, 1, 1, 0, 0, 0 };
 static const int fbx_alphafirst[FBX_FORMATS]=
-	{ 0, 0, 0, 0, 1, 1, 0 };
+	{ 0, 0, 0, 0, 1, 1, 0, 0 };
 static const int fbx_roffset[FBX_FORMATS]=
-	{ 0, 0, 2, 2, 3, 1, 0 };
+	{ 0, 0, 2, 2, 3, 1, 0, 0 };
 static const int fbx_goffset[FBX_FORMATS]=
-	{ 1, 1, 1, 1, 2, 2, 0 };
+	{ 1, 1, 1, 1, 2, 2, 1, 0 };
 static const int fbx_boffset[FBX_FORMATS]=
-	{ 2, 2, 0, 0, 1, 3, 0 };
+	{ 2, 2, 0, 0, 1, 3, 2, 0 };
 
 
 typedef struct _fbx_struct

--- a/server/faker-glx.cpp
+++ b/server/faker-glx.cpp
@@ -437,6 +437,7 @@ XVisualInfo *glXChooseVisual(Display *dpy, int screen, int *attrib_list)
 	if(vtemp)
 	{
 		if(vtemp->depth==32) depth=32;
+		if(vtemp->depth==30) depth=30;
 		XFree(vtemp);
 	}
 

--- a/util/fbx.c
+++ b/util/fbx.c
@@ -28,13 +28,13 @@ static int errorLine=-1;
 static FILE *warningFile=NULL;
 
 static const int fbx_rmask[FBX_FORMATS]=
-	{ 0x0000FF, 0x0000FF, 0xFF0000, 0xFF0000, 0x0000FF, 0xFF0000, 0 };
+	{ 0x0000FF, 0x0000FF, 0xFF0000, 0xFF0000, 0x0000FF, 0xFF0000, 0x3FF00000, 0 };
 static const int fbx_gmask[FBX_FORMATS]=
-	{ 0x00FF00, 0x00FF00, 0x00FF00, 0x00FF00, 0x00FF00, 0x00FF00, 0 };
+	{ 0x00FF00, 0x00FF00, 0x00FF00, 0x00FF00, 0x00FF00, 0x00FF00, 0x000ffc00, 0 };
 static const int fbx_bmask[FBX_FORMATS]=
-	{ 0xFF0000, 0xFF0000, 0x0000FF, 0x0000FF, 0xFF0000, 0x0000FF, 0 };
+	{ 0xFF0000, 0xFF0000, 0x0000FF, 0x0000FF, 0xFF0000, 0x0000FF, 0x000003ff, 0 };
 static const char *formatName[FBX_FORMATS]=
-	{ "RGB", "RGBA", "BGR", "BGRA", "ABGR", "ARGB", "INDEX" };
+	{ "RGB", "RGBA", "BGR", "BGRA", "ABGR", "ARGB", "r210", "INDEX" };
 
 
 #if defined(_WIN32)


### PR DESCRIPTION
This allows VirtualGL to forward 10 bits per channel pixel data using RGB10_A2 /
GL_UNSIGNED_INT_2_10_10_10_REV.

The seemingly unofficial fourcc code that I have found for this is "r210" so that's what I've used. ("R210" is for big endian)
The string "RGB10_A2" matches the OpenGL pixel format, but lacks the endianness distinction.

You can find all you need for testing and visually verifying that the extra bits are being forwarded without any subsampling here:
http://xpra.org/trac/ticket/1577#comment:2

Please let me know how you would like to proceed for merging this code, in particular any other required changes I might have missed, and where I should update the documentation, if anywhere.