### PR TITLE
vlgrun.in: requires bash

### DIFF
--- a/server/vglrun.in
+++ b/server/vglrun.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Copyright (C)2004 Landmark Graphics Corporation
 # Copyright (C)2005 Sun Microsystems, Inc.


### PR DESCRIPTION
The following is not allowed by posix:

```
exec ${1+"$@"}
```