### PR TITLE
Add aarch64 support in boost/endian.hpp

### DIFF
--- a/include/boost/endian.hpp
+++ b/include/boost/endian.hpp
@@ -112,7 +112,7 @@
    || defined(__amd64__) || defined(_M_AMD64) \
    || defined(__x86_64) || defined(__x86_64__) \
    || defined(_M_X64) || defined(__bfin__) \
-   || defined(__ARMEL__) \
+   || defined(__ARMEL__) || defined(__aarch64__) \
    || (defined(_WIN32) && defined(__ARM__) && defined(_MSC_VER)) // ARM Windows CE don't define anything reasonably unique, but there are no big-endian Windows versions
 
 # define BOOST_LITTLE_ENDIAN


### PR DESCRIPTION
The compiler macro is listed here:
https://sourceforge.net/p/predef/wiki/Architectures/

Fixes #91.