### PR TITLE
Add support for creating OpenGL ES contexts.

### DIFF
--- a/server/faker-glx.cpp
+++ b/server/faker-glx.cpp
@@ -1112,6 +1112,11 @@ static const char *getGLXExtensions(void)
 			" GLX_ARB_create_context GLX_ARB_create_context_profile",
 			1023 - strlen(glxextensions));
 
+	if(strstr(realGLXExtensions, "GLX_EXT_create_context_es2_profile")
+		&& !strstr(glxextensions, "GLX_EXT_create_context_es2_profile"))
+		strncat(glxextensions, " GLX_EXT_create_context_es2_profile",
+			1023 - strlen(glxextensions));
+
 	if(strstr(realGLXExtensions, "GLX_ARB_create_context_robustness")
 		&& !strstr(glxextensions, "GLX_ARB_create_context_robustness"))
 		strncat(glxextensions, " GLX_ARB_create_context_robustness",


### PR DESCRIPTION
Pass through the extension GLX_EXT_create_context_es2_profile to the client. Tested with a GLFW app that creates an OpenGL ES 2 context running in Chrome Remote Desktop.