### PR TITLE
Call IPC_RMID on the shm segment on FreeBSD as well as Linux

### DIFF
--- a/server/fakerconfig.cpp
+++ b/server/fakerconfig.cpp
@@ -97,7 +97,7 @@ FakerConfig *fconfig_getinstance(void)
 			if((addr = shmat(fconfig_shmid, 0, 0)) == (void *)-1) THROW_UNIX();
 			if(!addr)
 				THROW("Could not attach to config structure in shared memory");
-			#ifdef linux
+			#if defined(linux) || defined(__FreeBSD__)
 			shmctl(fconfig_shmid, IPC_RMID, 0);
 			#endif
 			char *env = NULL;


### PR DESCRIPTION
FreeBSD changed its default to allow attaching to removed segments 5 years ago; see
https://reviews.freebsd.org/D3603 .  This prevents orphaned segments from
being left around in case of a crash.