### PR TITLE
FBX: disable NoExposure events if SHM is not used

### DIFF
--- a/util/fbx.c
+++ b/util/fbx.c
@@ -410,6 +410,8 @@ int fbx_init(fbx_struct *fb, fbx_wh wh, int width_, int height_, int useShm)
 	fb->pixmap = pixmap;
 	TRY_X11(fb->xgc = XCreateGC(fb->wh.dpy, fb->pm ? fb->pm : fb->wh.d, 0,
 		NULL));
+	if (!useShm)
+		XSetGraphicsExposures(fb->wh.dpy, fb->xgc, False);
 	return 0;
 
 	finally:


### PR DESCRIPTION
On an environment where UDS comm. is available but IPC comm. is not (e.g. different IPC namespaces for vglrun-ned application & the turbovnc server), NoExpose events are queued on the vglrun-ned application until the memory is exhausted.

Fixes #155.