### PR TITLE
add -v option to vglconnect + vgllogin: execute SHELL under vglrun so VGL environment is arranged.

### DIFF
--- a/client/vglconnect.in
+++ b/client/vglconnect.in
@@ -25,6 +25,7 @@ CONNECT=1
 FORCE=0
 IPV6=0
 SSHCMD=ssh
+VRUN=
 
 usage()
 {
@@ -52,6 +53,7 @@ usage()
 	echo "-bindir <d> = Path in which the VGL executables and scripts are installed on"
 	echo "              the server (default: @CMAKE_INSTALL_DEFAULT_PREFIX@/bin).  Can also be set"
 	echo "              with the VGL_BINDIR environment variable on the client."
+	echo "-v = use vglrun to invoke SHELL."
 	echo
 	exit $1
 }
@@ -72,6 +74,7 @@ do
 	-k*) X11TUNNEL=0; VGLTUNNEL=0; CONNECT=0 ;;
 	-g*) SSHCMD=gsissh; GLOBUS=1 ;;
 	-e*) COMMAND=$2; shift ;;
+	-v*) VRUN=-v ;;
 	-h*) usage ;;
 	-?) usage ;;
 	*) break ;;
@@ -127,11 +130,11 @@ if [ $VGLTUNNEL = 1 ]; then
 	echo Making final SSH connection ...
 	if [ "$COMMAND" != "" ]; then
 		$SSHCMD -t -Y -R$REMOTEPORT:localhost:$PORT ${1+"$@"} <<EOF
-$VGL_BINDIR/vgllogin -s $REMOTEPORT
+$VGL_BINDIR/vgllogin $VRUN -s $REMOTEPORT
 $COMMAND
 EOF
 	else
-		$SSHCMD -t -Y -R$REMOTEPORT:localhost:$PORT ${1+"$@"} "$VGL_BINDIR/vgllogin -s "$REMOTEPORT
+		$SSHCMD -t -Y -R$REMOTEPORT:localhost:$PORT ${1+"$@"} "$VGL_BINDIR/vgllogin $VRUN -s "$REMOTEPORT
 	fi
 	exit 0
 fi
@@ -169,11 +172,11 @@ rm -f $XAUTHFILE
 if [ "$CONNECT" = "1" ]; then
 	if [ "$COMMAND" != "" ]; then
 		$SSHCMD -t -x ${1+"$@"} <<EOF
-$VGL_BINDIR/vgllogin -x $DISPLAY $XAUTHCOOKIE
+$VGL_BINDIR/vgllogin $VRUN -x $DISPLAY $XAUTHCOOKIE
 $COMMAND
 EOF
 	else
-		$SSHCMD -t -x ${1+"$@"} "exec $VGL_BINDIR/vgllogin -x "$DISPLAY" "$XAUTHCOOKIE
+		$SSHCMD -t -x ${1+"$@"} "exec $VGL_BINDIR/vgllogin $VRUN -x "$DISPLAY" "$XAUTHCOOKIE
 	fi
 else
 	DNUM=`echo $DISPLAY | sed 's/.*[:]//g'`

--- a/server/vgllogin
+++ b/server/vgllogin
@@ -16,12 +16,14 @@ if [ "$1" = "-check" ]; then exit 0; fi
 
 usage()
 {
-	echo "USAGE: $0 -s <server-side port on SSH tunnel>"
-	echo "       $0 -x <DISPLAY environment from client> <xauth MIT-MAGIC-COOKIE>"
+	echo "USAGE: $0 [-v] -s <server-side port on SSH tunnel>"
+	echo "       $0 [-v] -x <DISPLAY environment from client> <xauth MIT-MAGIC-COOKIE>"
 	exit 1
 }
 
 if [ "$1" = "" ]; then usage $0; fi
+
+[ "$1" = "-v" ] && VRUN=vglrun && shift || VRUN=
 
 if [ "$1" = "-s" ]; then
 
@@ -55,4 +57,4 @@ elif [ "$1" = "-x" ]; then
 	$XAUTH add $DISPLAY . $3
 fi
 
-exec $SHELL -l
+exec $VRUN $SHELL -l


### PR DESCRIPTION
A small change that I have found useful, so that individual commands don't need to be run under vglrun. Rather, login such that the shell itself is prep'd for the VGL environment, thus all child processes are VGL-capable.