### PR TITLE
Issue 195: Change X11Trans::getFrame to reuse display connection

### DIFF
--- a/server/X11Trans.cpp
+++ b/server/X11Trans.cpp
@@ -121,7 +121,7 @@ FBXFrame *X11Trans::getFrame(Display *dpy, Window win, int width, int height)
 				index = i;
 		if(index < 0) THROW("No free buffers in pool");
 		if(!frames[index])
-			frames[index] = new FBXFrame(dpy, win);
+                        frames[index] = new FBXFrame(dpy, win, NULL, true);
 		f = frames[index];  f->waitUntilComplete();
 	}
 


### PR DESCRIPTION
When running an auto-test-suite (Catch2 + Qt) which includes subsequent creation of many application
windows triggers the following issue

"Maximum number of clients reached[VGL] ERROR: in VirtualWin--[VGL]    77: Could not clone X display connection"

This happens because FBXFrames create their own display connection when instantiated in X11Trans::getFrame. The
display connection is closed in the destructor of FBXFrame which happens at the very end of the test suite when
a large amount of FBXFrames have piled up.

Observed call stack of FBXFrame creation:
X11Trans::getFrame
VirtualWin::sendx11
VirtualWin::readback
glxSwapBuffers