### PR TITLE
Don't allow null entries in fbconfig list

### DIFF
--- a/server/glxvisual.cpp
+++ b/server/glxvisual.cpp
@@ -988,17 +988,19 @@ VGLFBConfig *chooseFBConfig(Display *dpy, int screen, const int attribs[],
 		configs = (VGLFBConfig *)calloc(nElements, sizeof(VGLFBConfig));
 		if(!configs) goto bailout;
 
+		int nConfig = 0;
 		for(int i = 0; i < nElements; i++)
 		{
 			for(int j = 0; j < caEntries; j++)
 			{
 				if(ca[j].glx == glxConfigs[i])
 				{
-					configs[i] = &ca[j];
+					configs[nConfig++] = &ca[j];
 					break;
 				}
 			}
 		}
+		nElements = nConfig;
 	}
 
 	bailout:


### PR DESCRIPTION
glXChooseFBConfig() de-references nElements pointers in the returned list.

This could be triggered when the native GLX implementation is Mesa.

Fixes a SEGV in MATLAB when it uses software OpenGL rendering.

MATLAB dynamically decides what GL to use but you can force it to reproduce with:
    vglrun matlab -softwareopengl