### PR TITLE
Extend VGL_DISPLAY=egl to egl[:cuda|:mesa][:<n>]

### DIFF
--- a/server/faker-sym.h
+++ b/server/faker-sym.h
@@ -1080,6 +1080,9 @@ FUNCDEF3(EGLBoolean, eglQueryDevicesEXT, EGLint, max_devices, EGLDeviceEXT *,
 FUNCDEF2(const char *, eglQueryDeviceStringEXT, EGLDeviceEXT, device, EGLint,
 	name, NULL)
 
+FUNCDEF3(EGLBoolean, eglQueryDeviceAttribEXT, EGLDeviceEXT, device, EGLint,
+	name, EGLAttrib *, value, NULL)
+
 FUNCDEF0(EGLenum, eglQueryAPI, NULL)
 
 #endif


### PR DESCRIPTION
This makes VGL_DISPLAY=egl* more flexible in that it doesn't need to
simply select the first available GPU, but can use GPU n or a specific
CUDA device or the Mesa software renderer.

Background: on Compute Canada compute clusters, all managed via Slurm, the `/dev/dri/card[n]` devices are either not all present (because the `nvidia-drm` module is not loaded) or have restrictive permissions (`660` and `root:video`). Yet it's possible to use `VGL_DISPLAY=egl` without issue! However if a user reserves more than one GPU in a job (all restricted via cgroups), this isn't flexible enough.

What we see, when iterating through the EGL devices is this, when for example 2 GPUs are reserved:

0. 1st Nvidia GPU
1. 2nd Nvidia GPU
2. Mesa software renderer

`_eglQueryDeviceStringEXT(devices[i], EGL_DRM_DEVICE_FILE_EXT)` always returns `NULL` so is rejected.
`VGL_DISPLAY=egl` selects option 0 out of those and works.

Hence the proposed syntax, implemented in this patch for VGL_DISPLAY:
```
`egl:<n>` selects EGL device n, like Paraview's `--egl-device-index`.
`egl:mesa` selects the first Mesa renderer
`egl:mesa:<n>` selects the nth Mesa renderer (unusual to have more than 1, but consistent anyway)
`egl:cuda` selects the first CUDA device
`egl:cuda:<n>` selects CUDA device <n>, as in `$CUDA_VISIBLE_DEVICES`. Those are usually 0-based because of cgroup remapping.
```

Pros to this syntax:
* fully backward compatible, as the code already does `!strnicmp(env, "EGL", 3)` in `server/fakerconfig.cpp`.

Cons to this syntax:
* `egl:0` is actually a valid `$DISPLAY` notation for a node with hostname `egl`. Though this can't be used with 3.0.1 either and I suppose using VirtualGL with a remote display defeats the purpose.

Cons to this patch:
* The function `isValidEglDevice` is almost identical in `eglinfo.c` and in `faker.cpp` (just adapted for local tab-based and 3-space indentation, plus two parameters in eglinfo that are global in faker). So the duplication could be avoided in principle (header file?).

I've tested all combinations on a cluster where the `nvidia-drm` module is not loaded. They can probably be tested on a machine with a local GPU by revoking permissions on files in `/dev/dri`.

See also issues #157 (the driver issue was resolved in 470.57.02, see https://github.com/ComputeCanada/software-stack/issues/63) and #184.