### PR TITLE
Dropping use of register keyword

### DIFF
--- a/server/fltk/src/Fl_Text_Buffer.cxx
+++ b/server/fltk/src/Fl_Text_Buffer.cxx
@@ -1286,7 +1286,7 @@ int Fl_Text_Buffer::substitute_null_characters( char *string, int len ) {
 ** routine if no substitution has been done.
 */
 void Fl_Text_Buffer::unsubstitute_null_characters( char *string ) {
-  register char * c, subsChar = mNullSubsChar;
+  char * c, subsChar = mNullSubsChar;
 
   if ( subsChar == '\0' )
     return;

--- a/server/fltk/src/Fl_arg.cxx
+++ b/server/fltk/src/Fl_arg.cxx
@@ -314,7 +314,7 @@ without express or implied warranty.
 
 static int ReadInteger(char* string, char** NextString)
 {
-  register int Result = 0;
+  int Result = 0;
   int Sign = 1;
     
   if (*string == '+')
@@ -337,7 +337,7 @@ int XParseGeometry(const char* string, int* x, int* y,
 		   unsigned int* width, unsigned int* height)
 {
   int mask = NoValue;
-  register char *strind;
+  char *strind;
   unsigned int tempWidth = 0, tempHeight = 0;
   int tempX = 0, tempY = 0;
   char *nextCharacter;

--- a/util/md5.c
+++ b/util/md5.c
@@ -193,7 +193,7 @@ void MD5Final(unsigned char digest[16], struct MD5Context *ctx)
  */
 void MD5Transform(uint32 buf[4], uint32 in[16])
 {
-  register uint32 a, b, c, d;
+  uint32 a, b, c, d;
 
   a = buf[0];
   b = buf[1];


### PR DESCRIPTION
The usage of register keyword was deprecated in c++14 and it's completely removed in c++17. Found will building virtualgl on gentoo with clang-16.

Bug: https://bugs.gentoo.org/898876